### PR TITLE
Extend mystery machine patch to Sun & Moon.

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -8,7 +8,7 @@ If you want your patch in the release zips, submit a PR! As long as it does what
 Current contrib patches:
 
  * mysterymachine.pco
-   * Patches mystery gift in ORAS/XY to point to SALT servers (Based on work by @shinyquagsire23, contributed by @Wolfvak)
+   * Patches mystery gift in ORAS/XY/SM to point to SALT servers (Based on work by @shinyquagsire23, contributed by @Wolfvak)
 
  * svc_permission_chk_dis.pco
    * Disables SVC call permission checks. Potential security hazard. (Based on work by @Subv, contributed by @Wolfvak)

--- a/contrib/mysterymachine.pco
+++ b/contrib/mysterymachine.pco
@@ -1,6 +1,6 @@
 # $name  MysteryMachine Patcher (Loader)
-# $desc  Patches Mystery Gift in Pokemon X, Y, Omega Ruby, and Alpha Sapphire to point to SALT's servers. See <https://mys.salthax.org/>
-# $title 000400000011C400 000400000011C500 0004000000055D00 0004000000055E00
+# $desc  Patches Mystery Gift in Pokemon X, Y, Omega Ruby, Alpha Sapphire, Sun, and Moon to point to SALT's servers. See <https://mys.salthax.org/>
+# $title 000400000011C400 000400000011C500 0004000000055D00 0004000000055E00 0004000000164800 0004000000175E00
 # $ver   01
 # $uuid  0001
 
@@ -25,6 +25,10 @@ jmpf  seturl
 
 rewind
 find  "https://3ds2-fushigi.pokemon-gl.com/api/"
+jmpf  seturl
+
+rewind
+find  "https://3ds3-fushigi.pokemon-gl.com/api/"
 abortnf
 
 seturl:
@@ -43,3 +47,9 @@ find  "https://npfl.c.app.nintendowifi.net/p01/filelist/"
 abortnf
 set   "http://mys.salthax.org/p01/filelist/"
 set   00
+
+find  "https://npdl.cdn.nintendowifi.net/p01/nsa/%s/%s/%s/%s"
+jmpnf end
+set   "https://mys.salthax.org/p01/nsa/%s/%s/%s/%s"
+set   00
+end:


### PR DESCRIPTION
Note: I have not tested this myself.

This is based on #40, and seems to be the simple extension of what's already there. We may be able to shorten this by finding "-fushigi.pokemon-gl.com/api/" and seeking back a bit, but that's not the scope of this PR.

Speaking of PR scopes, this PR does not include a patch for no-outlines. I'd like to make that patch more dynamic, so that it works on all of the recent pokemon games. This PR also doesn't include a patch for the QR stuff. (I will note that I have not been able to get that to work as a corbenik patch yet, but I'm not going to give up on it.) Hopefully, these will come as part of a later PR.