### PR TITLE
Add patch to remove outlines in pokemon sun/moon

### DIFF
--- a/contrib/remove_outlines-sm.pco
+++ b/contrib/remove_outlines-sm.pco
@@ -1,0 +1,21 @@
+# $name  Remove Outlines - Pokemon S/M (Loader)
+# $desc  Patch to remove the outlines in the Pokemon Sun and Moon games
+# $title 0004000000164800 0004000000175E00
+# $ver   01
+# $uuid  0005
+
+# This is just a simple patch to remove the outlines in the Pokemon Sun and Moon games,
+# removing the need to extract and patch the code.bin.
+# Made it dynamic and ready when @kitling found a way to do it with all of the 
+# recent pokemon games.
+
+# The original patch was made by @SciresM. See here:
+#   https://github.com/SciresM/SunMoonPatches
+
+rel exe_text
+
+# Status: needs loader
+
+find E0042080E51E
+abortnf
+set  E000F020E3


### PR DESCRIPTION
I did it because I was with insonia. I made it dynamic but still only supports Pokemon Sun and Moon (I made sure that the pattern that I search cannot be found in the other pokemon games to avoid trouble for @kitling when he find a way to do it in those games and add then, so this patch will not change data of the other games when added) and I tested it.

I also preferred to repeat the first byte when using the set function instead of:

> find E0042080E51E
> abortnf
> fwd  01
> set  00F020E3

'Cause the vco became 1 byte smaller but if you prefer, you can change it at your will.