### PR TITLE
Fix for factory signature patch 

### DIFF
--- a/external/contrib_patch/1.x-2.x-factory-sigpatch.pco
+++ b/external/contrib_patch/1.x-2.x-factory-sigpatch.pco
@@ -1,11 +1,12 @@
 # $name Factory, 1.x, 2.x Signature Fix
 # $desc Disables signature checks on all content on Factory, 1.x, 2.x FIRM.
-# $title 0004013800000002 0004013820000002
+# $title 0004000100000002 0004013800000002 0004013820000002
 # $ver  01
 # $uuid 0006
 
-# Originally made by SciresM
-# Not tested
+# Originally implemented by SciresM.
+# Not tested with factory FIRM.
+# Factory NATIVE_FIRM have a different TID-high.
 
 rel  section2
 


### PR DESCRIPTION
My guess is, due the fact that factory titles for O3DS uses different TID-high, some code need to be add to fully support factory FIRM (patcher.c, firm.c and others, probably? Dunno, I'm not a C expert and I didn't read all corbenik code). I didn't thought about it till today when I saw that I forgot to add the v0 FIRM TID.

Nonetheless, I don't thing it's necessary to add support for factory systems. It would be cool, but unnecessary (at least for me).
I fix it anyway since I don't know if you plan to fully support factory systems.